### PR TITLE
【Update】Commit&testCommit

### DIFF
--- a/Commit.java
+++ b/Commit.java
@@ -39,7 +39,7 @@ public class Commit extends Hash{
             }    
         }
         else{ //若无HEAD文件，创建并设置previousCommit为空，创建Commit；
-            file.createNewFile();
+            HEAD.createNewFile();
             this.previousCommit="";
             createCommit(rootDirKey,author,committer,message);  
         }
@@ -68,6 +68,7 @@ public class Commit extends Hash{
 
     //从HEAD指针文件中读取上一次Commit的内容，也即上一次的根目录Key；
     public String readHEAD() throws IOException{
+        File HEAD=new File(Hash.objectpath + File.separator + "HEAD");
         this.previousCommit=Hash.readFromTextFile(HEAD);
         return previousCommit;
     }

--- a/Commit.java
+++ b/Commit.java
@@ -73,8 +73,8 @@ public class Commit extends Hash{
         }
         this.key = key;
 
-        //根据Key和Value创建Commit文件写入磁盘
-        Hash.writetofile(this.value,this.key);
+        //根据Key和Value储存为以key为名的Commit文件，写入磁盘
+        Hash.mystorage(this.key,this.value);
     }
 
     //从HEAD指针文件中读取上一次Commit的内容，也即上一次的根目录Key；

--- a/Commit.java
+++ b/Commit.java
@@ -60,18 +60,7 @@ public class Commit extends Hash{
         this.value += this.message+"\n";
         
         //根据value计算key
-        StringBuilder key = new StringBuilder();
-        try {
-            ByteArrayInputStream is = new ByteArrayInputStream(this.value.getBytes());
-            byte[] sha1 = Hash.SHA1Checksum(is);
-            for (int i=0;i<sha1.length;i++) {
-                key.append(Integer.toString((sha1[i]>>4)&0x0F, 16));
-                key.append(Integer.toString(sha1[i]&0x0F, 16));
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        this.key = key;
+        this.key=Hash.Treehash(this.value);
 
         //根据Key和Value储存为以key为名的Commit文件，写入磁盘
         Hash.mystorage(this.key,this.value);

--- a/Commit.java
+++ b/Commit.java
@@ -1,56 +1,89 @@
 import java.io.*;
 import java.util.*;
 
-public class Commit {
+public class Commit extends Hash{
     private String key; 
     private String value;
-    private String presentcommit;
+    protected String previousCommit; 
+    protected String rootTreeKey;       
+    protected String author;
+    protected String committer; 
+    protected String message;
     
-    public Commit(String rootDirPath) throws Exception {
-        String rootDirKey=Hash.prKVstore(rootDirPath)  //根据所给定工作区目录，对根文件夹进行遍历并返回对应key值；
+    //无参构造方法
+    public Commit(){}
+
+    //仅给定Commit的Key的构造方法
+    public Commit(String key){
+        this.key=key;
+    }
+
+    //给定根目录路径、作者信息、提交者信息、备注信息4个字符串参数的构造方法
+    public Commit(String rootDirPath,String author,String committer,String message) throws Exception {
+        //根据所给定工作区目录，对根文件夹进行遍历并返回对应key值
+        String rootDirKey=Hash.Show_KVstore(rootDirPath);
+        //创建HEAD File对象
         File HEAD=new File(Hash.objectpath + File.separator + "HEAD");
 
+        //判定工作目录下是否已有HEAD文件，分情况处理
         if(HEAD.exists()) {
-            if(getPresentcommit()==rootDirKey){
+            String lastRootDirKey=readHEAD();
+
+            if(lastRootDirKey==rootDirKey){ //若有HEAD文件且根目录Key与上次Commit中储存的根目录Key相同，则为重复提交，提示用户即可；
                 System.out.println("文件未发生变动，无需commit。" );
             }
-            else{
-                createCommit(rootDirKey);
+            else{//若有HEAD文件且根目录Key不同，读入previousCommit，创建Commit，更新HEAD指针文件；
+                this.previousCommit=lastRootDirKey;
+                createCommit(rootDirKey,author,committer,message);
                 updateHEAD(rootDirKey);
             }    
         }
-        else{
-            createCommit(rootDirKey);
-            createHEAD(rootDirKey);
-        }  
+        else{ //若无HEAD文件，创建并设置previousCommit为空，创建Commit；
+            file.createNewFile();
+            this.previousCommit="";
+            createCommit(rootDirKey,author,committer,message);  
+        }
     } 
 
-    public void createCommit(String rootDirKey){
+    //创建Commit
+    public void createCommit(String rootDirKey,String author,String committer,String message){
+        this.author=author;
+        this.committer=committer;
+        this.message=message;
+        this.rootTreeKey=rootDirKey;
+
         this.value ="";
-        this.value += "tree " + rootDirKey + "\n";
-        this.value += "parent " + getPresentcommit()+ "\n";
-        this.value += "author " + getAuthor() + "\n";
+        this.value += "tree " + this.rootTreeKey + "\n";
+        this.value += "parent " + this.previousCommit+ "\n";
+        this.value += "author " + this.author + "\n";
         this.value += "committer " + getCommitter() + "\n";
-        this.value += getUserInput()+"\n";
-        this.key = Hash.showhash(value);
-        Hash.mystorage(String this.key, String this.value);
-    }
-
-    public String getPresentcommit() throws IOException{
-        this.presentcommit=Hash.readObjectFromFile(File HEAD);
-        return presentcommit;
-    }
-
-    public void createHEAD(String rootDirKey){
+        this.value += this.message+"\n";
+        
+        //根据value计算key
+        StringBuilder key = new StringBuilder();
         try {
-            file.createNewFile();
-        } catch (IOException e) {
-            System.out.println("HEAD文件创建失败。");
+            ByteArrayInputStream is = new ByteArrayInputStream(this.value.getBytes());
+            byte[] sha1 = Hash.SHA1Checksum(is);
+            for (int i=0;i<sha1.length;i++) {
+                key.append(Integer.toString((sha1[i]>>4)&0x0F, 16));
+                key.append(Integer.toString(sha1[i]&0x0F, 16));
+            }
+        } catch (Exception e) {
             e.printStackTrace();
         }
-        updateHEAD(rootDirKey)；
+        this.key = key;
+
+        //根据Key和Value创建Commit文件写入磁盘
+        Hash.writetofile(this.value,this.key);
     }
 
+    //从HEAD指针文件中读取上一次Commit的内容，也即上一次的根目录Key；
+    public String readHEAD() throws IOException{
+        this.previousCommit=Hash.readFromTextFile(HEAD);
+        return previousCommit;
+    }
+
+    //更新HEAD，覆盖写入本次的根目录Key；
     public void updateHEAD(String rootDirKey){
         try {
             FileWriter writer;
@@ -62,38 +95,35 @@ public class Commit {
             System.out.println("HEAD文件更新失败。");
             e.printStackTrace();
         }
+    }   
+
+    //访问器：get方法
+
+    public String getRootTreeKey(){
+        return this.rootTreeKey;
     }
 
     public String getAuthor(){
-        System.out.println("请输入作者："); 
-        Scanner input = new Scanner(System.in);
-        String author = input.nextLine();
-        return author；
+        return this.author;
     }
 
     public String getCommitter(){
-        System.out.println("请输入该次commit的提交者："); 
-        Scanner input = new Scanner(System.in);
-        String committer = input.nextLine();
-        return committer；
+        return committer;
     }
 
-    public String getUserInput(){
-        System.out.println("请输入该次commit的备注："); 
-        Scanner input = new Scanner(System.in);
-        String UserInput = input.nextLine();
-        return UserInput；
+    public String getMessage(){
+        return message;
     }
 
-    public String returnKey(){
-        return this.key;
+    public String getKey(){
+        return key;
     }
 
-    public String returnValue(){
-        return this.value;
+    public String getValue(){
+        return value;
     }
 
-    public String returnPresentcommit(){
-        return this.presentcommit;
+    public String getPreviousCommit(){
+        return this.previousCommit;
     }
 }

--- a/Commit.java
+++ b/Commit.java
@@ -27,8 +27,8 @@ public class Commit extends Hash{
 
         //判定工作目录下是否已有HEAD文件，分情况处理
         if(HEAD.exists()) {
-            Commit lastCommit=new Commit(readHEAD());
-            String lastRootDirKey=lastCommit.getRootTreeKey();
+            String lastCommit=readHEAD();
+            String lastRootDirKey=readRootTreeKey(lastCommit);
 
             if(lastRootDirKey==rootDirKey){ //若有HEAD文件且根目录Key与上次Commit中储存的根目录Key相同，则为重复提交，提示用户即可；
                 System.out.println("文件未发生变动，无需commit。" );
@@ -80,7 +80,7 @@ public class Commit extends Hash{
         updateHEAD(this.key);
     }
 
-    //从HEAD指针文件中读取上一次Commit的内容，也即上一次的根目录Key；
+    //从HEAD指针文件中读取上一次Commit的内容,也即上一次Commit的key；
     public String readHEAD() throws IOException{
         File head=new File(Hash.objectpath + File.separator + "HEAD");
         this.previousCommit=Hash.readFromTextFile(head);
@@ -100,6 +100,15 @@ public class Commit extends Hash{
             e.printStackTrace();
         }
     }   
+
+    private String readRootTreeKey(String CommitKey)throws IOException{
+        File commitFile = new File(Hash.objectpath + "\\" + CommitKey);
+        Scanner input_read = new Scanner(commitFile);
+        String rTsign = input_read.next();
+        String rTKey = input_read.next();
+        return rTKey;
+        input_read.close();
+    }
 
     //访问器：get方法
 

--- a/Commit.java
+++ b/Commit.java
@@ -14,8 +14,8 @@ public class Commit extends Hash{
     public Commit(){}
 
     //仅给定Commit的Key的构造方法
-    public Commit(String key){
-        this.key=key;
+    public Commit(String givenCommitKey){
+        this.key=givenCommitKey;
     }
 
     //给定根目录路径、作者信息、提交者信息、备注信息4个字符串参数的构造方法
@@ -27,19 +27,19 @@ public class Commit extends Hash{
 
         //判定工作目录下是否已有HEAD文件，分情况处理
         if(HEAD.exists()) {
-            String lastRootDirKey=readHEAD();
+            Commit lastCommit=new Commit(readHEAD());
+            String lastRootDirKey=lastCommit.getRootTreeKey();
 
             if(lastRootDirKey==rootDirKey){ //若有HEAD文件且根目录Key与上次Commit中储存的根目录Key相同，则为重复提交，提示用户即可；
                 System.out.println("文件未发生变动，无需commit。" );
             }
             else{//若有HEAD文件且根目录Key不同，读入previousCommit，创建Commit，更新HEAD指针文件；
-                this.previousCommit=lastRootDirKey;
+                this.previousCommit=lastCommit.getKey();
                 createCommit(rootDirKey,author,committer,message);
-                updateHEAD(rootDirKey);
             }    
         }
         else{ //若无HEAD文件，创建并设置previousCommit为空，创建Commit；
-            HEAD.createNewFile();
+            file.createNewFile();
             this.previousCommit="";
             createCommit(rootDirKey,author,committer,message);  
         }
@@ -60,25 +60,38 @@ public class Commit extends Hash{
         this.value += this.message+"\n";
         
         //根据value计算key
-        this.key=Hash.Treehash(this.value);
+        StringBuilder key = new StringBuilder();
+        try {
+            ByteArrayInputStream is = new ByteArrayInputStream(this.value.getBytes());
+            byte[] sha1 = Hash.SHA1Checksum(is);
+            for (int i=0;i<sha1.length;i++) {
+                key.append(Integer.toString((sha1[i]>>4)&0x0F, 16));
+                key.append(Integer.toString(sha1[i]&0x0F, 16));
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        this.key = key;
 
-        //根据Key和Value储存为以key为名的Commit文件，写入磁盘
+        //根据Key和Value创建Commit文件写入磁盘
         Hash.mystorage(this.key,this.value);
+
+        //更新HEAD指针
+        updateHEAD(this.key);
     }
 
     //从HEAD指针文件中读取上一次Commit的内容，也即上一次的根目录Key；
     public String readHEAD() throws IOException{
-        File HEAD=new File(Hash.objectpath + File.separator + "HEAD");
         this.previousCommit=Hash.readFromTextFile(HEAD);
         return previousCommit;
     }
 
     //更新HEAD，覆盖写入本次的根目录Key；
-    public void updateHEAD(String rootDirKey){
+    public void updateHEAD(String key){
         try {
             FileWriter writer;
             writer =new FileWriter(Hash.objectpath + File.separator + "HEAD");
-            writer.write(rootDirKey);
+            writer.write(key);
             writer.flush();
             writer.close();
         } catch (IOException e) {

--- a/Commit.java
+++ b/Commit.java
@@ -82,7 +82,8 @@ public class Commit extends Hash{
 
     //从HEAD指针文件中读取上一次Commit的内容，也即上一次的根目录Key；
     public String readHEAD() throws IOException{
-        this.previousCommit=Hash.readFromTextFile(HEAD);
+        File head=new File(Hash.objectpath + File.separator + "HEAD");
+        this.previousCommit=Hash.readFromTextFile(head);
         return previousCommit;
     }
 

--- a/testCommit.java
+++ b/testCommit.java
@@ -18,7 +18,6 @@ public class testCommit {
 		
         System.out.println("本次Commit的Value为："+testCommit.getValue());
         System.out.println("本次Commit的Key为："+testCommit.getKey());
-		
 	input.close();
 	}
 

--- a/testCommit.java
+++ b/testCommit.java
@@ -1,0 +1,23 @@
+import java.io.IOException;
+import java.util.Scanner;
+
+public class testCommit {
+	public static void main(String args[])throws IOException {
+        Scanner input = new Scanner(System.in);
+        System.out.println("请输入Commit根目录路径：");
+        String rootDirPath= input.next();
+        System.out.println("请输入作者名：");
+        String author= input.next();
+        System.out.println("请输入提交者名：");
+        String committer= input.next();
+        System.out.println("请输入备注信息：");
+        String message= input.next();
+
+        Commit testCommit=new Commit(rootDirPath,author,committer,message);
+        
+        System.out.println("本次Commit的Value为："+testCommit.getValue());
+        System.out.println("本次Commit的Key为："+testCommit.getKey());
+
+	}
+
+}

--- a/testCommit.java
+++ b/testCommit.java
@@ -18,7 +18,8 @@ public class testCommit {
 		
         System.out.println("本次Commit的Value为："+testCommit.getValue());
         System.out.println("本次Commit的Key为："+testCommit.getKey());
-	input.close();
+	
+		input.close();
 	}
 
 }

--- a/testCommit.java
+++ b/testCommit.java
@@ -2,7 +2,7 @@ import java.util.Scanner;
 
 public class CommitTest{
     public static void main(String[] args) {
-        // 首次运行时须运行此部分，避免出错 (此部分by张楠 @ZhangNan13）
+        // 首次运行时须运行此部分，避免出错 ————此部分by张楠 @ZhangNan13
         //Hash.initsetting();
         //Branch.branchcreate("main","");
         //Branch.branchchange("main");

--- a/testCommit.java
+++ b/testCommit.java
@@ -15,10 +15,10 @@ public class testCommit {
         String message= input.next();
 
         Commit testCommit=new Commit(rootDirPath,author,committer,message);
-        
+		
         System.out.println("本次Commit的Value为："+testCommit.getValue());
         System.out.println("本次Commit的Key为："+testCommit.getKey());
-	
+		
 	input.close();
 	}
 

--- a/testCommit.java
+++ b/testCommit.java
@@ -2,10 +2,10 @@ import java.util.Scanner;
 
 public class CommitTest{
     public static void main(String[] args) {
-        // 首次运行时须运行此部分，避免出错 ————此部分by张楠 @ZhangNan13
-        //Hash.initsetting();
-        //Branch.branchcreate("main","");
-        //Branch.branchchange("main");
+        // 首次运行时须运行此部分，避免出错
+        // Hash.initsetting();
+        // Branch.branchcreate("main","");
+        // Branch.branchchange("main");
         try {
             // 提示用户输入文件夹路径名
             System.out.println("请输入文件夹路径：" );
@@ -18,9 +18,9 @@ public class CommitTest{
             System.out.println("请输入备注信息：");
             String message= input.next();
             input.close();
-            Commit testCommit=new Commit(rootDirPath,author,committer,message);
-            testCommit.createCommit(testCommit);
-            System.out.println("本次Commit的Value为："+testCommit.getValue());
+            Commit testCommit = Commit.createCommit(rootDirPath, author, committer, message);
+            System.out.println("本次Commit的Value为：");
+            System.out.println(testCommit.getValue());
             System.out.println("本次Commit的Key为："+testCommit.getKey());
         } catch (Exception e) {
             e.printStackTrace();

--- a/testCommit.java
+++ b/testCommit.java
@@ -18,8 +18,7 @@ public class testCommit {
 		
         System.out.println("本次Commit的Value为："+testCommit.getValue());
         System.out.println("本次Commit的Key为："+testCommit.getKey());
-	
-		input.close();
+	input.close();
+		
 	}
-
 }

--- a/testCommit.java
+++ b/testCommit.java
@@ -1,24 +1,29 @@
-import java.io.IOException;
 import java.util.Scanner;
 
-public class testCommit {
-	public static void main(String args[])throws IOException {
-		
-        Scanner input = new Scanner(System.in);
-        System.out.println("请输入Commit根目录路径：");
-        String rootDirPath= input.next();
-        System.out.println("请输入作者名：");
-        String author= input.next();
-        System.out.println("请输入提交者名：");
-        String committer= input.next();
-        System.out.println("请输入备注信息：");
-        String message= input.next();
-
-        Commit testCommit=new Commit(rootDirPath,author,committer,message);
-		
-        System.out.println("本次Commit的Value为："+testCommit.getValue());
-        System.out.println("本次Commit的Key为："+testCommit.getKey());
-	input.close();
-		
-	}
+public class CommitTest{
+    public static void main(String[] args) {
+        // 首次运行时须运行此部分，避免出错 (此部分by张楠 @ZhangNan13）
+        //Hash.initsetting();
+        //Branch.branchcreate("main","");
+        //Branch.branchchange("main");
+        try {
+            // 提示用户输入文件夹路径名
+            System.out.println("请输入文件夹路径：" );
+            Scanner input = new Scanner(System.in);
+            String rootDirPath = input.next();
+            System.out.println("请输入作者名：");
+            String author= input.next();
+            System.out.println("请输入提交者名：");
+            String committer= input.next();
+            System.out.println("请输入备注信息：");
+            String message= input.next();
+            input.close();
+            Commit testCommit=new Commit(rootDirPath,author,committer,message);
+            testCommit.createCommit(testCommit);
+            System.out.println("本次Commit的Value为："+testCommit.getValue());
+            System.out.println("本次Commit的Key为："+testCommit.getKey());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/testCommit.java
+++ b/testCommit.java
@@ -3,21 +3,23 @@ import java.util.Scanner;
 
 public class testCommit {
 	public static void main(String args[])throws IOException {
+		
         Scanner input = new Scanner(System.in);
-        System.out.println("ÇëÊäÈëCommit¸ùÄ¿Â¼Â·¾¶£º");
+        System.out.println("è¯·è¾“å…¥Commitæ ¹ç›®å½•è·¯å¾„ï¼š");
         String rootDirPath= input.next();
-        System.out.println("ÇëÊäÈë×÷ÕßÃû£º");
+        System.out.println("è¯·è¾“å…¥ä½œè€…åï¼š");
         String author= input.next();
-        System.out.println("ÇëÊäÈëÌá½»ÕßÃû£º");
+        System.out.println("è¯·è¾“å…¥æäº¤è€…åï¼š");
         String committer= input.next();
-        System.out.println("ÇëÊäÈë±¸×¢ĞÅÏ¢£º");
+        System.out.println("è¯·è¾“å…¥å¤‡æ³¨ä¿¡æ¯ï¼š");
         String message= input.next();
 
         Commit testCommit=new Commit(rootDirPath,author,committer,message);
         
-        System.out.println("±¾´ÎCommitµÄValueÎª£º"+testCommit.getValue());
-        System.out.println("±¾´ÎCommitµÄKeyÎª£º"+testCommit.getKey());
-
+        System.out.println("æœ¬æ¬¡Commitçš„Valueä¸ºï¼š"+testCommit.getValue());
+        System.out.println("æœ¬æ¬¡Commitçš„Keyä¸ºï¼š"+testCommit.getKey());
+	
+	input.close();
 	}
 
 }


### PR DESCRIPTION
1.6更新（此部分代码修改by张楠）：
为将commit改为【基于分支实现】，配合Branch类，HEAD指针转入Branch中实现，方法修改为静态，提交功能通过createCommmit实现，提交后更新HEAD指针的功能改为更新分支信息（实质的指针记录功能相同）；
——

+更新了构造方法：
   现有 1）无参构造方法、2）commit key为参数的构造方法、3）工作目录下根目录路径（相对路径）、作者、提交者、备注信息为参数的构造方法；
    第三种用于提交，第二种可仅根据key创建Commit对象，用于配合其他功能所需的查询解析；

+增加了数据域，规范了方法命名，修改了一些方法的实现，并做了一些删减修正；

   目前数据域：key，value, previousCommit, rootTreeKey, author, committer, message.
   目前方法域：(除构造方法外)
           public void createCommit(String rootDirKey,String author,String committer,String message);
           public String readHEAD();
           public void updateHEAD(String rootDirKey);
           以及数据域对应的七个访问器；

@ZhangNan13 @wxc1217 @js00070
